### PR TITLE
Fix #22: Remove the fruit bonus when Pac-Man dies

### DIFF
--- a/src/js/helper-functions.js
+++ b/src/js/helper-functions.js
@@ -478,6 +478,8 @@ export function loseLife(){
   stopAllSounds();
   soundDeath.play();
   lives -= 1;
+  squares[489].classList.remove('bonusFruit');
+  squares[489].innerHTML = '';
   
   if(lives>0){
     document.querySelector('.pac-man-lives').remove();


### PR DESCRIPTION
## Fix: Remove fruit bonus when Pac-Man dies (#22)

This PR resolves #22 by updating the `loseLife` function to immediately remove the fruit bonus from the board when Pac-Man loses a life.

**What was changed:**
- Added two lines to `loseLife`:
  - `squares[489].classList.remove('bonusFruit');`
  - `squares[489].innerHTML = '';`
- These ensure that any active fruit bonus is cleared from the board and the emoji is removed, keeping gameplay consistent with classic arcade behavior.

**Acceptance criteria met:**
- The fruit bonus is removed when Pac-Man dies.
- The fruit does not remain or reappear after Pac-Man respawns.