### PR TITLE
Feature/20 pacman tunnel speed

### DIFF
--- a/src/js/game-board.js
+++ b/src/js/game-board.js
@@ -178,10 +178,7 @@ export function setTunnel() {
     squares[394].classList.add('tunnel');
     squares[395].classList.add('tunnel');
     squares[396].classList.add('tunnel');
-    squares[397].classList.add('tunnel');
-    squares[398].classList.add('tunnel');
 
-    squares[414].classList.add('tunnel');
     squares[415].classList.add('tunnel');
     squares[416].classList.add('tunnel');
     squares[417].classList.add('tunnel');

--- a/src/js/helper-functions.js
+++ b/src/js/helper-functions.js
@@ -249,6 +249,12 @@ export let pacmanCurrentIndex = 658;
 // squares[658].classList.add('pacMan-move-left');
 
 export function control(x) {
+    // Determine how many steps to move
+    const inTunnel = squares[pacmanCurrentIndex].classList.contains('tunnel');
+    const steps = inTunnel ? 2 : 1; // Move 2 steps in tunnel, 1 elsewhere
+
+   for (let i = 0; i < steps; i++) { 
+
     squares[pacmanCurrentIndex].classList.remove('pacMan', 'pacMan-move-left', 'pacMan-move-right', 'pacMan-move-up', 'pacMan-move-down');
     switch(pacmanCurrentDirection) {
         case 'down':
@@ -341,6 +347,8 @@ export function control(x) {
     highScoreDisplaySpan.innerText = highScore;
 
     // stopPacManEatingPelletsSound();
+    
+   } // end for steps 
   } // control
 
 function fruitScoreBonus(){

--- a/src/styles/_game-board.scss
+++ b/src/styles/_game-board.scss
@@ -38,7 +38,7 @@
 }
 
 .tunnel {
-  background-color: lightgreen;
+  background-color: black;
 }
 
 .level-completed {


### PR DESCRIPTION
**Summary:**
It adds a classic tunnel speed boost for Pac-Man and refines tunnel logic for smoother entry/exit and improved gameplay.

**Key Changes:**

* Pac-Man moves faster only in the tunnel center squares.
*  `setTunnel()` now targets only true tunnel squares for accurate speed boost and smooth transitions.
* Tunnel class management improved to prevent glitches.

**Acceptance Criteria:**

* Pac-Man speeds up in the tunnel and returns to normal speed outside.
* Tunnel entry/exit is smooth and matches arcade behavior.

**Testing:**

* Verified speed boost only in the tunnel center.
* Confirmed no tunnel class glitches at entrances/exits.