### PR TITLE
feat: add blinking effect to 'Press Start' message (#34)

### DIFF
--- a/src/js/game-board.js
+++ b/src/js/game-board.js
@@ -483,6 +483,38 @@ export function setScoreScreen() {
     squares[805].innerHTML = "!";  
 } // setScoreScreen
 
+export function addBlinkToPressStart() {    
+    squares[793].classList.add('blink');
+    squares[794].classList.add('blink');
+    squares[795].classList.add('blink');
+    squares[796].classList.add('blink');
+    squares[797].classList.add('blink');
+    squares[798].classList.add('blink');
+
+    squares[800].classList.add('blink');
+    squares[801].classList.add('blink');
+    squares[802].classList.add('blink');
+    squares[803].classList.add('blink');
+    squares[804].classList.add('blink');
+    squares[805].classList.add('blink');    
+}
+
+export function removeBlinkFromPressStart() {
+    squares[793].classList.remove('blink');
+    squares[794].classList.remove('blink');
+    squares[795].classList.remove('blink');
+    squares[796].classList.remove('blink');
+    squares[797].classList.remove('blink');
+    squares[798].classList.remove('blink');
+
+    squares[800].classList.remove('blink');
+    squares[801].classList.remove('blink');
+    squares[802].classList.remove('blink');
+    squares[803].classList.remove('blink');
+    squares[804].classList.remove('blink');
+    squares[805].classList.remove('blink');
+}
+
 export function setGameBoard() { 
     reSetLairTextColor();
     for(let i = 0; i < squares.length; i++) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import './styles/style.scss'
 import { buildGameBoard } from './js/game-board.js';
 import { width, toggleGameBoardSize, pacmanCurrentIndex, pacManDirection, pacmanCurrentDirection, control, score, highScore, fruitBonus, levelCurrent, level, fruitBonusCurrent, loseLife, ctnPacManLives, checkForHighScore, player1Start } from './js/helper-functions.js';
-import { squares, gameGrid, buildTheBoard, setTitleScreen, setScoreScreen } from './js/game-board.js';
+import { squares, gameGrid, buildTheBoard, setTitleScreen, setScoreScreen, addBlinkToPressStart, removeBlinkFromPressStart } from './js/game-board.js';
 
 // let flagToggleTittleAndScoreScreen;
 let intervalTitleAndScoreScreen = null;
@@ -13,6 +13,7 @@ buildTheBoard();
 // Start Toggle Title And ScoreScreen
 export function startToggleTitleAndScoreScreen() {
   player1Start.classList.add("blink");
+  addBlinkToPressStart();
   setTitleScreen();
   if(intervalTitleAndScoreScreen === null) {
     let flagToggleTitleAndScoreScreen = true;
@@ -33,6 +34,7 @@ startToggleTitleAndScoreScreen();
 // End Toggle Tittle And ScoreScreen
 export function endToggleTitleAndScoreScreen() {
   player1Start.classList.remove("blink");
+  removeBlinkFromPressStart();
   if(intervalTitleAndScoreScreen !== null) {
     clearInterval(intervalTitleAndScoreScreen);
     intervalTitleAndScoreScreen = null;


### PR DESCRIPTION
### PR: Add blinking effect to "Press Start" message (#34)

**Description:**  
This PR implements a blinking effect for the "Press Start" message on the title screen, enhancing the UI and making it closer to the classic arcade experience.

**Changes:**
- Added `.blink` class to the relevant squares during the attract/title screen.
- Removed `.blink` class when the game starts.
- Updated main.js and game-board.js to use `addBlinkToPressStart()` and `removeBlinkFromPressStart()` functions.
- Tested to ensure the effect works and stops as expected.

**Acceptance Criteria:**
- "Press Start" blinks at a regular interval on the title screen.
- Blinking stops when the game begins.
- Code is clean, commented, and easy to maintain.

Closes #34